### PR TITLE
Simplify InputStrategySwitcher constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.darzalgames</groupId>
 	<artifactId>libgdx-tools</artifactId>
-	<version>0.6.0</version>
+	<version>0.6.1</version>
 	<name>libGDX Tools</name>
 
 	<properties>

--- a/src/main/java/com/darzalgames/libgdxtools/maingame/MainGame.java
+++ b/src/main/java/com/darzalgames/libgdxtools/maingame/MainGame.java
@@ -29,8 +29,6 @@ import com.darzalgames.libgdxtools.ui.input.handler.MouseInputHandler;
 import com.darzalgames.libgdxtools.ui.input.inputpriority.InputSetup;
 import com.darzalgames.libgdxtools.ui.input.inputpriority.OptionsMenu;
 import com.darzalgames.libgdxtools.ui.input.strategy.InputStrategySwitcher;
-import com.darzalgames.libgdxtools.ui.input.strategy.KeyboardAndGamepadInputStrategy;
-import com.darzalgames.libgdxtools.ui.input.strategy.MouseInputStrategy;
 import com.darzalgames.libgdxtools.ui.input.universaluserinput.button.UserInterfaceFactory;
 import com.darzalgames.libgdxtools.ui.screen.GameScreen;
 
@@ -201,7 +199,7 @@ public abstract class MainGame extends ApplicationAdapter implements SharesGameI
 	}
 
 	private void makeInputStrategySwitcher() {
-		inputStrategySwitcher = new InputStrategySwitcher(new MouseInputStrategy(), new KeyboardAndGamepadInputStrategy());
+		inputStrategySwitcher = new InputStrategySwitcher();
 	}
 
 	private void makePreferenceManager() {

--- a/src/main/java/com/darzalgames/libgdxtools/ui/input/strategy/InputStrategySwitcher.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/input/strategy/InputStrategySwitcher.java
@@ -20,9 +20,9 @@ public class InputStrategySwitcher extends Actor implements InputStrategy, Input
 	private final InputStrategy mouseInputStrategy;
 	private final InputStrategy keyboardAndGamepadInputStrategy;
 
-	public InputStrategySwitcher(InputStrategy mouseInputStrategy, InputStrategy keyboardAndGamepadInputStrategy) {
-		this.mouseInputStrategy = mouseInputStrategy;
-		this.keyboardAndGamepadInputStrategy = keyboardAndGamepadInputStrategy;
+	public InputStrategySwitcher() {
+		mouseInputStrategy = new MouseInputStrategy();
+		keyboardAndGamepadInputStrategy = new KeyboardAndGamepadInputStrategy();
 
 		observers = new ArrayList<>();
 		setToMouseStrategy();

--- a/src/test/java/com/darzalgames/libgdxtools/ui/input/CustomCursorImageTest.java
+++ b/src/test/java/com/darzalgames/libgdxtools/ui/input/CustomCursorImageTest.java
@@ -7,14 +7,12 @@ import org.junit.jupiter.api.Test;
 
 import com.darzalgames.libgdxtools.ui.CustomCursorImage;
 import com.darzalgames.libgdxtools.ui.input.strategy.InputStrategySwitcher;
-import com.darzalgames.libgdxtools.ui.input.strategy.KeyboardAndGamepadInputStrategy;
-import com.darzalgames.libgdxtools.ui.input.strategy.MouseInputStrategy;
 
 class CustomCursorImageTest {
 
 	@Test
 	void isVisible_duringMouseStrategy_returnsTrue() throws Exception {
-		InputStrategySwitcher inputStrategySwitcher = new InputStrategySwitcher(new MouseInputStrategy(), new KeyboardAndGamepadInputStrategy());
+		InputStrategySwitcher inputStrategySwitcher = new InputStrategySwitcher();
 		CustomCursorImage customCursor = new CustomCursorImage(() -> true, null, inputStrategySwitcher);
 		
 		inputStrategySwitcher.setToMouseStrategy();
@@ -24,7 +22,7 @@ class CustomCursorImageTest {
 	
 	@Test
 	void isVisible_duringKeyboardStrategy_returnsFalse() throws Exception {
-		InputStrategySwitcher inputStrategySwitcher = new InputStrategySwitcher(new MouseInputStrategy(), new KeyboardAndGamepadInputStrategy());
+		InputStrategySwitcher inputStrategySwitcher = new InputStrategySwitcher();
 		CustomCursorImage customCursor = new CustomCursorImage(() -> true, null, inputStrategySwitcher);
 		
 		inputStrategySwitcher.setToKeyboardAndGamepadStrategy();

--- a/src/test/java/com/darzalgames/libgdxtools/ui/input/keyboard/button/MouseOnlyButtonTest.java
+++ b/src/test/java/com/darzalgames/libgdxtools/ui/input/keyboard/button/MouseOnlyButtonTest.java
@@ -18,8 +18,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
 import com.darzalgames.darzalcommon.functional.Runnables;
 import com.darzalgames.darzalcommon.functional.Suppliers;
 import com.darzalgames.libgdxtools.ui.input.strategy.InputStrategySwitcher;
-import com.darzalgames.libgdxtools.ui.input.strategy.KeyboardAndGamepadInputStrategy;
-import com.darzalgames.libgdxtools.ui.input.strategy.MouseInputStrategy;
 import com.darzalgames.libgdxtools.ui.input.universaluserinput.button.MouseOnlyButton;
 import com.darzalgames.libgdxtools.ui.input.universaluserinput.button.MyTextButton;
 import com.darzalgames.libgdxtools.ui.input.universaluserinput.button.UniversalButton;
@@ -52,7 +50,7 @@ class MouseOnlyButtonTest {
 		Gdx.graphics = new MockGraphics();
 		Gdx.files = Mockito.mock(Files.class);
 		
-		inputStrategySwitcher = new InputStrategySwitcher(new MouseInputStrategy(), new KeyboardAndGamepadInputStrategy());
+		inputStrategySwitcher = new InputStrategySwitcher();
 		inputStrategySwitcher.setToMouseStrategy();
 		TextButtonStyle textButtonStyle =  new TextButtonStyle();
 		textButtonStyle.font = new BitmapFont(new BitmapFontData(), new TextureRegion(), false);

--- a/src/test/java/com/darzalgames/libgdxtools/ui/input/navigablemenu/NavigableListTest.java
+++ b/src/test/java/com/darzalgames/libgdxtools/ui/input/navigablemenu/NavigableListTest.java
@@ -551,7 +551,7 @@ public class NavigableListTest {
 	}
 	
 	private static InputStrategySwitcher makeInputStrategySwitcher() {
-		return new InputStrategySwitcher(null, null) {
+		return new InputStrategySwitcher() {
 			@Override
 			public boolean shouldFlashButtons() {
 				return true;


### PR DESCRIPTION
simplify the constructor for InputStrategySwitcher, since the 2 strategies really don't ever need to be anything different (at least at the moment)