### PR TITLE
Renaming InputObserver 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.darzalgames</groupId>
 	<artifactId>libgdx-tools</artifactId>
-	<version>0.6.9</version>
+	<version>0.6.10</version>
 	<name>libGDX Tools</name>
 
 	<properties>

--- a/src/main/java/com/darzalgames/libgdxtools/hexagon/twodee/NavigableHexagonMap2D.java
+++ b/src/main/java/com/darzalgames/libgdxtools/hexagon/twodee/NavigableHexagonMap2D.java
@@ -5,14 +5,14 @@ import com.badlogic.gdx.scenes.scene2d.ui.Container;
 import com.darzalgames.darzalcommon.hexagon.Hexagon;
 import com.darzalgames.darzalcommon.hexagon.HexagonDirection;
 import com.darzalgames.libgdxtools.ui.input.*;
-import com.darzalgames.libgdxtools.ui.input.inputpriority.InputObserver;
+import com.darzalgames.libgdxtools.ui.input.inputpriority.InputStrategyObserver;
 import com.darzalgames.libgdxtools.ui.input.strategy.InputStrategySwitcher;
 
 /**
  * Allows for navigation around a {@link HexagonControllerMap2D} using keyboard or gamepad
  * @param <E> The game-specific object associated with each {@link Hexagon} and {@link HexagonController2D}
  */
-public class NavigableHexagonMap2D<E> extends Container<HexagonControllerMap2D<E>> implements InputConsumer, InputObserver {
+public class NavigableHexagonMap2D<E> extends Container<HexagonControllerMap2D<E>> implements InputConsumer, InputStrategyObserver {
 
 	private Hexagon currentHexagon;
 

--- a/src/main/java/com/darzalgames/libgdxtools/ui/CustomCursorImage.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/CustomCursorImage.java
@@ -11,10 +11,10 @@ import com.badlogic.gdx.scenes.scene2d.Touchable;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.darzalgames.darzalcommon.state.DoesNotPause;
 import com.darzalgames.libgdxtools.graphics.windowresizer.WindowResizer;
-import com.darzalgames.libgdxtools.ui.input.inputpriority.InputObserver;
+import com.darzalgames.libgdxtools.ui.input.inputpriority.InputStrategyObserver;
 import com.darzalgames.libgdxtools.ui.input.strategy.InputStrategySwitcher;
 
-public class CustomCursorImage extends Image implements DoesNotPause, InputObserver {
+public class CustomCursorImage extends Image implements DoesNotPause, InputStrategyObserver {
 
 	private final Supplier<Boolean> checkIsWindowed;
 	private final TextureRegion cursorTexture;

--- a/src/main/java/com/darzalgames/libgdxtools/ui/input/UniversalInputStage.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/input/UniversalInputStage.java
@@ -4,10 +4,10 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
 import com.badlogic.gdx.utils.viewport.Viewport;
-import com.darzalgames.libgdxtools.ui.input.inputpriority.InputObserver;
+import com.darzalgames.libgdxtools.ui.input.inputpriority.InputStrategyObserver;
 import com.darzalgames.libgdxtools.ui.input.strategy.InputStrategySwitcher;
 
-public class UniversalInputStage extends OptionalDrawStage implements InputObserver {
+public class UniversalInputStage extends OptionalDrawStage implements InputStrategyObserver {
 
 	private boolean mouseMode;
 

--- a/src/main/java/com/darzalgames/libgdxtools/ui/input/inputpriority/InputPriorityStack.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/input/inputpriority/InputPriorityStack.java
@@ -16,7 +16,7 @@ import com.darzalgames.libgdxtools.ui.input.strategy.InputStrategySwitcher;
 /**
  * Manages which input consumer (including popups) is in focus and receiving input
  */
-public class InputPriorityStack implements InputObserver, InputPrioritySubject {
+public class InputPriorityStack implements InputStrategyObserver, InputPrioritySubject {
 
 	private final LimitedAccessDoubleStack stack;
 	private final DarkScreen darkScreen;

--- a/src/main/java/com/darzalgames/libgdxtools/ui/input/inputpriority/InputStrategyObserver.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/input/inputpriority/InputStrategyObserver.java
@@ -2,7 +2,7 @@ package com.darzalgames.libgdxtools.ui.input.inputpriority;
 
 import com.darzalgames.libgdxtools.ui.input.strategy.InputStrategySwitcher;
 
-public interface InputObserver {
+public interface InputStrategyObserver {
 	void inputStrategyChanged(InputStrategySwitcher inputStrategySwitcher);
 
 	/*

--- a/src/main/java/com/darzalgames/libgdxtools/ui/input/inputpriority/InputStrategySubject.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/input/inputpriority/InputStrategySubject.java
@@ -1,0 +1,8 @@
+package com.darzalgames.libgdxtools.ui.input.inputpriority;
+
+public interface InputStrategySubject {
+	public void register(InputStrategyObserver obj);
+	public void unregister(InputStrategyObserver obj);
+	
+	public void notifyObservers();
+}

--- a/src/main/java/com/darzalgames/libgdxtools/ui/input/inputpriority/InputSubject.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/input/inputpriority/InputSubject.java
@@ -1,8 +1,0 @@
-package com.darzalgames.libgdxtools.ui.input.inputpriority;
-
-public interface InputSubject {
-	public void register(InputObserver obj);
-	public void unregister(InputObserver obj);
-	
-	public void notifyObservers();
-}

--- a/src/main/java/com/darzalgames/libgdxtools/ui/input/strategy/InputStrategySwitcher.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/input/strategy/InputStrategySwitcher.java
@@ -7,13 +7,13 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.actions.DelayAction;
 import com.darzalgames.darzalcommon.state.DoesNotPause;
 import com.darzalgames.libgdxtools.scenes.scene2d.actions.RunnableActionBest;
-import com.darzalgames.libgdxtools.ui.input.inputpriority.InputObserver;
-import com.darzalgames.libgdxtools.ui.input.inputpriority.InputSubject;
+import com.darzalgames.libgdxtools.ui.input.inputpriority.InputStrategyObserver;
+import com.darzalgames.libgdxtools.ui.input.inputpriority.InputStrategySubject;
 
 /**
  * Tracks the current input strategy, and handles switching between them as needed.
  */
-public class InputStrategySwitcher extends Actor implements InputStrategy, InputSubject, DoesNotPause {
+public class InputStrategySwitcher extends Actor implements InputStrategy, InputStrategySubject, DoesNotPause {
 
 	private InputStrategy currentInputStrategy;
 	private InputStrategy previousInputStrategy;
@@ -52,21 +52,21 @@ public class InputStrategySwitcher extends Actor implements InputStrategy, Input
 	}
 
 
-	private final List<InputObserver> observers;
+	private final List<InputStrategyObserver> observers;
 	@Override
-	public void register(InputObserver obj) {
+	public void register(InputStrategyObserver obj) {
 		observers.add(obj);
 		// Let the new observer know right away what the current input strategy is, since they pretty much always need to know!
 		// e.g. The stage needs to know on initialization that everything starts in mouse mode; a newly created input-sensitive label uses the current strategy, etc.
 		obj.inputStrategyChanged(this);
 	}
 	@Override
-	public void unregister(InputObserver obj) {
+	public void unregister(InputStrategyObserver obj) {
 		observers.remove(obj);
 	}
 	@Override
 	public void notifyObservers() {
-		List<InputObserver> toRemove = observers.stream().filter(InputObserver::shouldBeUnregistered).toList();
+		List<InputStrategyObserver> toRemove = observers.stream().filter(InputStrategyObserver::shouldBeUnregistered).toList();
 		observers.removeAll(toRemove);
 		observers.stream().forEach(observer -> observer.inputStrategyChanged(this));
 	}

--- a/src/main/java/com/darzalgames/libgdxtools/ui/input/universaluserinput/button/MouseOnlyButton.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/input/universaluserinput/button/MouseOnlyButton.java
@@ -3,14 +3,14 @@ package com.darzalgames.libgdxtools.ui.input.universaluserinput.button;
 import java.util.function.Supplier;
 
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
-import com.darzalgames.libgdxtools.ui.input.inputpriority.InputObserver;
+import com.darzalgames.libgdxtools.ui.input.inputpriority.InputStrategyObserver;
 import com.darzalgames.libgdxtools.ui.input.strategy.InputStrategySwitcher;
 
 
 /**
  * A {@link UniversalButton} which will only be visible and intractable in mouse mode
  */
-public class MouseOnlyButton extends UniversalButton implements InputObserver {
+public class MouseOnlyButton extends UniversalButton implements InputStrategyObserver {
 
 	public MouseOnlyButton(BasicButton textButton, Supplier<String> textSupplier, Runnable runnable, InputStrategySwitcher inputStrategySwitcher, Runnable soundInteractListener) {
 		super(textButton, textSupplier, runnable, inputStrategySwitcher, soundInteractListener);

--- a/src/main/java/com/darzalgames/libgdxtools/ui/input/universaluserinput/button/UniversalInputSensitiveLabel.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/input/universaluserinput/button/UniversalInputSensitiveLabel.java
@@ -3,10 +3,10 @@ package com.darzalgames.libgdxtools.ui.input.universaluserinput.button;
 import java.util.function.Supplier;
 
 import com.badlogic.gdx.scenes.scene2d.Group;
-import com.darzalgames.libgdxtools.ui.input.inputpriority.InputObserver;
+import com.darzalgames.libgdxtools.ui.input.inputpriority.InputStrategyObserver;
 import com.darzalgames.libgdxtools.ui.input.strategy.InputStrategySwitcher;
 
-public class UniversalInputSensitiveLabel extends UniversalLabel implements InputObserver {
+public class UniversalInputSensitiveLabel extends UniversalLabel implements InputStrategyObserver {
 	
 	private final InputStrategySwitcher inputStrategySwitcher;
 


### PR DESCRIPTION
Renaming old InputObserver to InputStrategyObserver since that's what it is and we now have more than one "input observer" (the new InputPriorityObserver)