### PR TITLE
fix a bug where an interrupted pop up menu lost its listener for "right click to go back"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.darzalgames</groupId>
 	<artifactId>libgdx-tools</artifactId>
-	<version>0.4.7-questgiver</version>
+	<version>0.4.8-questgiver</version>
 	<name>libGDX Tools</name>
 
 	<properties>

--- a/src/main/java/com/darzalgames/libgdxtools/ui/input/popup/PopUpMenu.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/input/popup/PopUpMenu.java
@@ -53,8 +53,8 @@ public abstract class PopUpMenu extends NavigableListMenu implements PopUp {
 
 	@Override
 	public void regainFocus() {
-		gainFocus();
-		addBackClickListenerIfCanDismiss(); // calling gainFocus() clears this listener, so put it back on
+		super.regainFocus();
+		addBackClickListenerIfCanDismiss(); // calling super.regainFocus() clears this listener, so put it back on
 	}
 	
 	@Override

--- a/src/main/java/com/darzalgames/libgdxtools/ui/input/popup/PopUpMenu.java
+++ b/src/main/java/com/darzalgames/libgdxtools/ui/input/popup/PopUpMenu.java
@@ -50,6 +50,12 @@ public abstract class PopUpMenu extends NavigableListMenu implements PopUp {
 		this.setY(getStage().getHeight());
 		this.addAction(Actions.moveTo(startX, startY, 0.25f, Interpolation.circle));
 	}
+
+	@Override
+	public void regainFocus() {
+		gainFocus();
+		addBackClickListenerIfCanDismiss(); // calling gainFocus() clears this listener, so put it back on
+	}
 	
 	@Override
 	public void hideThis() {


### PR DESCRIPTION
This affected the scenario map when a scenario is unlocked, as well as the contract pop up menu (one layer below choosing hero/quest)